### PR TITLE
BaseObject Problem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "yiisoft/yii2-jui": "@dev"
+    "yiisoft/yii2-jui": "@dev",
+    "yiisoft/yii2": ">=2.0.13"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
BaseObject is introduced in Yii 2.0.13 so this version produce exception on lower versions.